### PR TITLE
pom.xml - move properties section before dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,14 @@
     <groupId>iservice</groupId>
     <artifactId>service-sdk</artifactId>
     <version>1.0-SNAPSHOT</version>
+         
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+        <java.version>1.8</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -97,13 +105,7 @@
             <version>0.11.0</version>
         </dependency>
     </dependencies>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+         
     <distributionManagement>
         <repository>
             <id>maven-releases</id>


### PR DESCRIPTION
properties section before dependencies is industry best practice, as properties often define dependency versions in cleaner way